### PR TITLE
Fix install + bump to version 1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A collaborative editor to work on notes written in Markdown
 
-**Shipped version:** 1.5.0
+**Shipped version:** 1.6.0
 
 **Status**: In progress, do *not* consider this app as stable and fully working (yet)
 

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://github.com/codimd/server/archive/1.5.0.tar.gz
-SOURCE_SUM=2321fb054c85e5ffcb73443e3ea9fbf8c370387f2b5709a23c21f71233fdb454
+SOURCE_URL=https://github.com/codimd/server/archive/1.6.0.tar.gz
+SOURCE_SUM=3639eaf70a37ee0513c75259c70b3d0c2c10116e9b2989dc9c571f98017120bd
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/manifest.json
+++ b/manifest.json
@@ -36,7 +36,7 @@
                     "en": "Is it a public site ?",
                     "fr": "Est-ce un site public ?"
                 },
-                "default": "true"
+                "default": true
             }
         ]
     }

--- a/scripts/install
+++ b/scripts/install
@@ -64,7 +64,7 @@ ynh_install_app_dependencies postgresql apt-transport-https
 # Install Yarn
 ynh_install_extra_app_dependencies --repo="deb https://dl.yarnpkg.com/debian/ stable main" --package="yarn" --key="https://dl.yarnpkg.com/debian/pubkey.gpg"
 
-ynh_install_nodejs 8
+ynh_install_nodejs 10
 
 #==============================================
 # CREATE DB

--- a/scripts/install
+++ b/scripts/install
@@ -62,7 +62,7 @@ ynh_script_progression --message="Installing dependencies..."
 ynh_install_app_dependencies postgresql apt-transport-https
 
 # Install Yarn
-ynh_install_extra_app_dependencies --repo="deb https://dl.yarnpkg.com/debian/ stable main" --package="yarn" --key="https://dl.yarnpkg.com/debian/pubkey.gpg"
+ynh_install_extra_app_dependencies --repo="deb https://dl.yarnpkg.com/debian/ stable main" --package="yarn=1.19.2-1" --key="https://dl.yarnpkg.com/debian/pubkey.gpg"
 
 ynh_install_nodejs 8
 

--- a/scripts/install
+++ b/scripts/install
@@ -105,7 +105,7 @@ cp ../conf/.sequelizerc.example "$final_path"/.sequelizerc
 #==============================================
 # INSTALL CODIMD
 #==============================================
-ynh_script_progression --message="Building application... (this may take some time and resources!)"
+ynh_script_progression --message="Building application... (this will take some time and resources!)"
 
 pushd "$final_path" || exit
 
@@ -118,10 +118,9 @@ if [ ! -f .sequelizerc ]; then
   cp .sequelizerc.example .sequelizerc
 fi
 
-yarn install
-yarn install --production=false  # FIXME: this doesn't sounds like what we want to have for a real deployment ? idk
+yarn install --non-interactive
+yarn install --non-interactive --production=false  # FIXME: this doesn't sounds like what we want to have for a real deployment ? idk
 # ---- End copypasta from https://raw.githubusercontent.com/codimd/server/master/bin/setup
-
 
 yarn run build
 #node_modules/.bin/sequelize db:migrate

--- a/scripts/install
+++ b/scripts/install
@@ -62,7 +62,7 @@ ynh_script_progression --message="Installing dependencies..."
 ynh_install_app_dependencies postgresql apt-transport-https
 
 # Install Yarn
-ynh_install_extra_app_dependencies --repo="deb https://dl.yarnpkg.com/debian/ stable main" --package="yarn (<1.20)" --key="https://dl.yarnpkg.com/debian/pubkey.gpg"
+ynh_install_extra_app_dependencies --repo="deb https://dl.yarnpkg.com/debian/ stable main" --package="yarn(<1.20)" --key="https://dl.yarnpkg.com/debian/pubkey.gpg"
 
 ynh_install_nodejs 8
 

--- a/scripts/install
+++ b/scripts/install
@@ -62,7 +62,7 @@ ynh_script_progression --message="Installing dependencies..."
 ynh_install_app_dependencies postgresql apt-transport-https
 
 # Install Yarn
-ynh_install_extra_app_dependencies --repo="deb https://dl.yarnpkg.com/debian/ stable main" --package="yarn(<1.20)" --key="https://dl.yarnpkg.com/debian/pubkey.gpg"
+ynh_install_extra_app_dependencies --repo="deb https://dl.yarnpkg.com/debian/ stable main" --package="yarn" --key="https://dl.yarnpkg.com/debian/pubkey.gpg"
 
 ynh_install_nodejs 8
 

--- a/scripts/install
+++ b/scripts/install
@@ -62,7 +62,7 @@ ynh_script_progression --message="Installing dependencies..."
 ynh_install_app_dependencies postgresql apt-transport-https
 
 # Install Yarn
-ynh_install_extra_app_dependencies --repo="deb https://dl.yarnpkg.com/debian/ stable main" --package="yarn<=1.20" --key="https://dl.yarnpkg.com/debian/pubkey.gpg"
+ynh_install_extra_app_dependencies --repo="deb https://dl.yarnpkg.com/debian/ stable main" --package="yarn(<=1.20)" --key="https://dl.yarnpkg.com/debian/pubkey.gpg"
 
 ynh_install_nodejs 8
 

--- a/scripts/install
+++ b/scripts/install
@@ -62,7 +62,7 @@ ynh_script_progression --message="Installing dependencies..."
 ynh_install_app_dependencies postgresql apt-transport-https
 
 # Install Yarn
-ynh_install_extra_app_dependencies --repo="deb https://dl.yarnpkg.com/debian/ stable main" --package="yarn(<=1.20)" --key="https://dl.yarnpkg.com/debian/pubkey.gpg"
+ynh_install_extra_app_dependencies --repo="deb https://dl.yarnpkg.com/debian/ stable main" --package="yarn (<1.20)" --key="https://dl.yarnpkg.com/debian/pubkey.gpg"
 
 ynh_install_nodejs 8
 

--- a/scripts/install
+++ b/scripts/install
@@ -62,7 +62,7 @@ ynh_script_progression --message="Installing dependencies..."
 ynh_install_app_dependencies postgresql apt-transport-https
 
 # Install Yarn
-ynh_install_extra_app_dependencies --repo="deb https://dl.yarnpkg.com/debian/ stable main" --package="yarn=1.19.2-1" --key="https://dl.yarnpkg.com/debian/pubkey.gpg"
+ynh_install_extra_app_dependencies --repo="deb https://dl.yarnpkg.com/debian/ stable main" --package="yarn<=1.20" --key="https://dl.yarnpkg.com/debian/pubkey.gpg"
 
 ynh_install_nodejs 8
 

--- a/scripts/install
+++ b/scripts/install
@@ -108,7 +108,21 @@ cp ../conf/.sequelizerc.example "$final_path"/.sequelizerc
 ynh_script_progression --message="Building application... (this may take some time and resources!)"
 
 pushd "$final_path" || exit
-./bin/setup
+
+# ---- This is copypasta from https://raw.githubusercontent.com/codimd/server/master/bin/setup
+if [ ! -f config.json ]; then
+  cp config.json.example config.json
+fi
+
+if [ ! -f .sequelizerc ]; then
+  cp .sequelizerc.example .sequelizerc
+fi
+
+yarn install
+yarn install --production=false  # FIXME: this doesn't sounds like what we want to have for a real deployment ? idk
+# ---- End copypasta from https://raw.githubusercontent.com/codimd/server/master/bin/setup
+
+
 yarn run build
 #node_modules/.bin/sequelize db:migrate
 popd || exit

--- a/scripts/ynh_add_extra_apt_repos__3
+++ b/scripts/ynh_add_extra_apt_repos__3
@@ -128,7 +128,7 @@ ynh_install_extra_repo () {
 	local component="${repo##$uri $suite }"
 
 	# Add the repository into sources.list.d
-	ynh_add_repo --uri="$uri" --suite="$suite" --component="$component" --name="$name" "$append"
+	ynh_add_repo --uri="$uri" --suite="$suite" --component="$component" --name="$name" $append
 
 	# Pin the new repo with the default priority, so it won't be used for upgrades.
 	# Build $pin from the uri without http and any sub path
@@ -139,7 +139,7 @@ ynh_install_extra_repo () {
 	then
 		priority="--priority=$priority"
 	fi
-	ynh_pin_repo --package="*" --pin="origin \"$pin\"" "$priority" --name="$name" "$append"
+	ynh_pin_repo --package="*" --pin="origin \"$pin\"" "$priority" --name="$name" $append
 
 	# Get the public key for the repo
 	if [ -n "$key" ]


### PR DESCRIPTION
This is to upgrade to CodiMD version 1.6, issue #18 

Tested on a Debian 9 virtual machine with yunohost 3.6.5.3.

CodiMD version 1.6 is supposed to still be compatible with nodejs version 8 but there was an error of a dependency complaining about nodejs version being too old. So I had to bump node version

The first commits are reverted. they were attempts at pinning yarn version to an older release to work around the issue with yarn error `no such option: --pure-lockfile`. 
I failed at doing that in the script. I'm new to yunohost API 
Instead I did it with a file on the server, as described in https://github.com/YunoHost-Apps/codimd_ynh/issues/17#issuecomment-596600690