### PR TITLE
[autopatch] TEST BEFORE MERGE ynh_setup_source --full_replace=1

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ CodiMD is the free software version of HackMD, developed and opened source by th
 
 CodiMD is perfect for open communities, while HackMD emphasizes on permission and access controls for commercial use cases.
 
-**Shipped version:** 2.5.0~ynh1
+**Shipped version:** 2.5.3~ynh1
 
 ## Screenshots
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -20,7 +20,7 @@ CodiMD est la version logicielle libre de HackMD, développée et ouverte par l'
 
 CodiMD est parfait pour les communautés ouvertes, tandis que HackMD met l'accent sur les autorisations et les contrôles d'accès pour les cas d'utilisation commerciale.
 
-**Version incluse :** 2.5.0~ynh1
+**Version incluse :** 2.5.3~ynh1
 
 ## Captures d’écran
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "CodiMD"
 description.en = "Collaborative editor to work on notes written in Markdown"
 description.fr = "Éditeur collaboratif pour travailler sur des notes en Markdown"
 
-version = "2.5.0~ynh1"
+version = "2.5.3~ynh1"
 
 maintainers = ["eric_G"]
 
@@ -41,8 +41,8 @@ ram.runtime = "50M"
 
 [resources]
         [resources.sources.main]
-        url = "https://github.com/hackmdio/codimd/archive/refs/tags/2.5.0.tar.gz"
-        sha256 = "cc20033fdeabddbe7c0305864c8b46d0b7c691986150b45278cdd785358e2598"
+        url = "https://github.com/hackmdio/codimd/archive/refs/tags/2.5.3.tar.gz"
+        sha256 = "28289aec6f2b8c2cd134af2b88b8076cf0f50da58855eda2dac6813a374df33d"
         autoupdate.strategy = "latest_github_tag"
 
     [resources.ports]

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -33,7 +33,7 @@ then
 	ynh_script_progression --message="Upgrading source files..." --weight=16
 
 	# Download, check integrity, uncompress and patch the source from app.src
-	ynh_setup_source --dest_dir=$install_dir --keep="config.json .sequelizerc"
+	ynh_setup_source --dest_dir=$install_dir --full_replace=1 --keep="config.json .sequelizerc"
 fi
 
 chmod -R o-rwx "$install_dir"


### PR DESCRIPTION
This is an automatic PR

This is an ***automated*** patch to potentially fix a bug in the upgrade script.

`ynh_setup_source` doesn't overwrite the destination directory, but rather extracts the source in the existing directory.

This might lead to weird cases where legacy source files aren't deleted.

The command has an argument `--full_replace=1` that fixes this behaviour.

BE CAREFUL because this change might lead to data losses! You should check that all the patches calls to `ynh_setup_source`
_do exactly what you expect to do_ and don't **delete user data**.

If you want exclude some files from being overwritten/deleted, use the `--keep` argument, just like that:

```bash
ynh_setup_source --dest_dir="$install_dir" --full_replace=1 --keep="config/config.yaml"
```